### PR TITLE
Profanity maintenance on backend with api for frontend

### DIFF
--- a/app/controllers/admin/profanities_controller.rb
+++ b/app/controllers/admin/profanities_controller.rb
@@ -1,0 +1,93 @@
+class Admin::ProfanitiesController < ApplicationController
+	layout "admin_panel_sidenav"
+  before_action :authenticate_user!
+	before_action :require_admin, only: [:index, :update, :edit, :show, :destroy]
+	before_action :set_profanity, only: [:edit, :update, :show, :destroy]
+
+	def index
+		@profanities = Profanity.all.includes(:created_by).order(profane_word: :asc).filter_by(params[:page], filter_params.to_h, sort_params.to_h)
+		respond_to do |format|
+			if request.xhr?
+				format.html {render partial: "admin/profanities/table", locals: { profanities: @profanities } }
+			else
+				format.html
+			end
+	    end
+	end
+
+	def show
+	end
+
+	def update
+		if @profanity.update(secure_params)
+			redirect_to admin_profanity_path(@profanity), flash_success_info: "Profane word was successfully updated."
+		else
+			redirect_back fallback_location: root_path, flash_info: "Profane word was not successfully updated."
+		end
+	end
+
+	def destroy
+		@profanity.destroy
+		redirect_to admin_profanities_path, flash_success_info: "Profane word was successfully deleted."
+	end
+
+	def new
+		@profanity = Profanity.new
+	end
+
+	def create
+		@profanity = Profanity.new(secure_params.merge(created_by: current_user))
+		if Profanity.where(profane_word: secure_params[:profane_word]).empty?
+			if @profanity.save 
+				redirect_to admin_profanity_path(@profanity), flash_success_info: "Profane word was successfully created."
+			else
+				flash[:flash_info] = "Profane word was not successfully created."
+			render :new
+			end
+		else
+			flash[:flash_info] = "Profane word is already present and duplicate profane words cannot be inserted. Please Update the profane word instead."
+			render :new
+		end
+  	end
+
+	def import_profanities
+		if (params[:profanities_placeholder].present? && params[:profanities_placeholder][:file].present?)
+		  import = Profanity.import_profanities(params[:profanities_placeholder][:file],current_user.id)
+		  if import[:status] == "true"
+			redirect_to admin_profanities_path, flash_success_info: "#{import[:records_count]} profanities imported successfully"
+		  else
+			redirect_to admin_profanities_path, flash_info: "Something went wrong, please try again later."
+		  end
+		else
+		  redirect_to admin_profanities_path, flash_info: "File not found."
+		end
+	end
+
+	def export_as_excel
+		respond_to do |format|
+			@profanities = Profanity.all.order(profane_word: :asc).filter_by(params[:page], filter_params.to_h, sort_params.to_h)
+			@profanities = @profanities.data.list(@profanities.facets.filtered_count, nil, nil)
+			ProfanityExportEmailJob.perform_later(@profanities.data.to_a, current_user.email)
+			format.html { redirect_back fallback_location: admin_profanities_path, flash_success_info: "Profane Word details was successfully exported will email you shortly." }
+		end
+	end
+
+	private
+
+	def secure_params
+		params.require(:profanity).permit(:profane_word)
+	end
+
+	def set_profanity
+		@profanity = Profanity.find(params[:id])
+	end
+
+  def sort_params
+    params.require(:sort).permit(:sort_column, :sort_direction) if params[:sort]
+  end
+
+  def filter_params
+    params.require(:filters).permit(:search_profane_word) if params[:filters]
+  end
+
+end

--- a/app/graphql/queries/profanity/list.rb
+++ b/app/graphql/queries/profanity/list.rb
@@ -1,0 +1,17 @@
+module Queries
+	module Profanity
+		class List < Queries::BaseQuery
+	    description "Get a list of profane words"
+	    argument :page,						Int,		required: false, default_value: 1
+	    argument :per_page,					Int,		required: false, default_value: 10
+	    argument :sort,						Types::Enums::ProfanitySorts, 	required: false, default_value: nil
+	    argument :sort_direction,			Types::Enums::SortDirections,	required: false, default_value: nil
+
+	    type Types::Objects::Profanity::List, null: true
+
+	    def resolve(per_page:, page:, sort:, sort_direction:)
+	    	::Profanity.sort_records(sort, sort_direction).list(per_page, page)
+	    end
+		end
+	end
+end

--- a/app/graphql/types/enums/profanity_sorts.rb
+++ b/app/graphql/types/enums/profanity_sorts.rb
@@ -1,0 +1,3 @@
+class Types::Enums::ProfanitySorts < Types::BaseEnum
+    value "profane_word"
+  end

--- a/app/graphql/types/objects/profanity/base.rb
+++ b/app/graphql/types/objects/profanity/base.rb
@@ -1,0 +1,13 @@
+module Types
+	module Objects
+		module Profanity
+			class Base < BaseObject
+				graphql_name "ProfanityBase"
+				field :id,							Int, "ID of the profane word", null: false
+				field :profane_word,				String, nil, null: false
+				field :created_by,					Types::Objects::User::Base, nil, null: false
+				field :created_at,					Types::Objects::DateTime, nil, null: false
+			end
+		end
+	end
+end

--- a/app/graphql/types/objects/profanity/list.rb
+++ b/app/graphql/types/objects/profanity/list.rb
@@ -1,0 +1,11 @@
+module Types
+	module Objects
+		module Profanity
+			class List < BaseObject
+				graphql_name "ListProfanityType"
+				field :data,							[Types::Objects::Profanity::Base], nil, null: true
+				field :paging,							Types::Objects::Paging,            nil, null: false
+			end
+		end
+	end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -21,6 +21,7 @@ module Types
     field :user_profile,                       resolver: Queries::User::Profile
     field :glossary_list,                      resolver: Queries::Glossary::List
     field :glossary_word,                      resolver: Queries::Glossary::Profile
+    field :profanity_list,                     resolver: Queries::Profanity::List
     field :user_count_user,                    resolver: Queries::UserCount::User
   end
 end

--- a/app/jobs/profanity_export_email_job.rb
+++ b/app/jobs/profanity_export_email_job.rb
@@ -1,0 +1,7 @@
+class ProfanityExportEmailJob < ApplicationJob
+  queue_as :default
+
+  def perform(profanities, email)
+    UserMailer.profanity_export_email_job(profanities, email).deliver_now
+  end
+end

--- a/app/models/concerns/import_profanities.rb
+++ b/app/models/concerns/import_profanities.rb
@@ -1,0 +1,78 @@
+module ImportProfanities
+  extend ActiveSupport::Concern
+  require 'roo'
+  require 'roo-xls' 
+
+  module ClassMethods
+    def import_fields_from_files(object,user_id)
+      begin
+        result = {}
+        file = csv_parse(object)
+        headers = set_headers(file)
+        required_headers = set_required_headers
+        missing_headers =  missing_headers(required_headers, headers)
+        if missing_headers.present?
+          p " -------------- Missing headers ------------ "
+          p missing_headers
+        else
+          records = []
+          file.each_with_index do |row, index|
+            hash = row.to_h
+            hash.merge!({"created_by_id": user_id})
+            profane_word_value = hash["profane_word"]
+            profane_word = Profanity.find_by(profane_word: profane_word_value)
+            if profane_word.present?
+              Profanity.delete(profane_word.id)
+            end
+            records << hash
+          end
+          import_records(records) if records.present?
+          return result.merge!(status: "true", records_count: records.size)
+        end
+      rescue Exception => e
+        Rollbar.error(e)
+        return result.merge!(status: "false")
+      end
+    end
+
+    def csv_parse(file)
+      content_type = File.extname(file.original_filename.to_s)
+      if content_type.include?('csv')
+        csv_file = open(file.path)
+        csv_file = csv_file.string rescue csv_file.read
+        csv_file = csv_file.force_encoding("UTF-8").sub("\xEF\xBB\xBF", '')
+      else
+        begin
+          xlsx = Roo::Spreadsheet.open(file.path, extension: :xlsx)
+        rescue Zip::Error
+          xlsx = Roo::Spreadsheet.open(file.path, extension: :xls)
+        end
+        begin
+          xlsx.default_sheet = 'Import Data'
+        rescue
+          xlsx.default_sheet = xlsx.sheets.last
+        end 
+        csv_file = xlsx.to_csv
+      end
+      file = CSV.parse(csv_file, headers: true)
+    end
+
+    def set_headers(file)
+      file.headers.reject(&:blank?)
+    end
+
+    def missing_headers(required_headers, headers)
+      required_headers - headers
+    end
+
+    def set_required_headers
+      required_headers = ["profane_word"]
+    end
+
+    def import_records(records)
+      ActiveRecord::Base.transaction do
+        self.create!(records)
+      end
+    end
+  end
+end

--- a/app/models/profanity.rb
+++ b/app/models/profanity.rb
@@ -1,0 +1,29 @@
+class Profanity < ApplicationRecord
+    include SpotlightSearch
+    include ImportProfanities
+    include Paginator
+  
+      validates :profane_word,  presence: true
+  
+    belongs_to :created_by, foreign_key: "created_by_id", class_name: "User"
+  
+    scope :alphabetical, -> { order(profane_word: :asc) }
+    
+    scope :search_profane_word, lambda { |query = nil|
+      return nil unless query
+      where("profane_word ILIKE (?)", "%#{query}%")
+    }
+
+    scope :sort_records, lambda { |sort, sort_direction = "asc"|
+      return nil if sort.blank?
+      order("#{sort} #{sort_direction}")
+    }
+
+    def format_for_csv(field_name)
+      self[field_name.to_sym].present? ? self[field_name.to_sym] : "NA"
+    end
+    
+    def self.import_profanities(file,user_id)
+      self.import_fields_from_files(file,user_id)
+    end
+end

--- a/app/views/admin/profanities/_form.html.slim
+++ b/app/views/admin/profanities/_form.html.slim
@@ -1,0 +1,8 @@
+= simple_form_for [:admin, @profanity], data: { id: "add_edit_profanity_detail" } do |f|
+	.p-4
+		.admin-header-text
+			| Profane Words
+		.admin-details-box
+			= f.input :profane_word, placeholder: "Profane Word", required: false, autofocus: true, wrapper: :form_input_group, input_html: { id: "profane_word" }
+		.admin-update-button-position
+			= f.button :submit, "Save Profane Word"

--- a/app/views/admin/profanities/_table.html.slim
+++ b/app/views/admin/profanities/_table.html.slim
@@ -1,0 +1,19 @@
+.admin-index-records-found
+  = total_no_of_records_found(@profanities, "profanities", "facets")
+.admin-index-records-found-text
+  | Showing #{@profanities.data.size} profanities
+table.table.mt-3
+      thead
+        tr
+          th.width-35 Profane Word
+          th Created By
+      tbody
+        - @profanities.data.each do |profanity|
+          tr.pointer onclick='window.location="#{admin_profanity_path(profanity)}";'
+            td.table-bold-title
+              = profanity&.profane_word
+            td
+              = profanity&.created_by&.full_name
+.pagination-parent
+  - if @profanities.facets.total_count > 0
+    = cm_paginate(@profanities.facets)

--- a/app/views/admin/profanities/edit.html.slim
+++ b/app/views/admin/profanities/edit.html.slim
@@ -1,0 +1,14 @@
+- navigation_add 'Profane Words', admin_profanities_path
+- navigation_add "#{@profanity&.profane_word}", edit_admin_profanity_path(@profanity)
+= render_navigation
+- flash.each do |key, value|
+	- if (key == "flash_info" || key == "flash_success_info")
+		div class=("alert #{key}") = value
+.admin-content-wrapper
+	.admin-filter-bg
+		.admin-filter-parent
+			.admin-filter-child.width-75
+				.admin-filter-child-field
+					.admin-index-title DETAILS
+	.admin-list-bg
+		= render 'form'

--- a/app/views/admin/profanities/index.html.slim
+++ b/app/views/admin/profanities/index.html.slim
@@ -1,0 +1,46 @@
+- navigation_add 'Profane Words', admin_profanities_path
+= render_navigation
+- flash.each do |key, value|
+  - if (key == "flash_info" || key == "flash_success_info")
+    div class=("alert #{key}") = value
+.bg-white.p-3
+  .admin-filter-bg.box-shadow-none
+    .admin-filter-parent
+      .admin-filter-child.width-75
+        .admin-filter-child-field
+          .admin-index-title-bold Profane Word
+  .admin-filters-wrap
+    .admin-filter-parent.pl-0
+      .admin-filter-child.width-100
+        .col-md-2
+          .filters data-filter-url="/admin/profanities" data-replacement-class="profanities_table"
+            .input-group.search
+              input.form-control.filter-box name=("search_term_for_profane_words") placeholder=("Search profanities") type="text" data-behaviour="filter" data-scope="search_profane_word" data-type="input-filter"
+    .admin-table.profanities_table
+      = render 'table'
+    br
+  .admin-update-button-position
+    = link_to "New Profane Word", new_admin_profanity_path, class: "button"
+    = link_to '', {class: "button", id: "import_glossary", 'data-target': "#importModal", 'data-toggle': "modal", 'type': "button"} do
+      | Import Profane Words from csv file
+    = link_to "Export as excel", export_as_excel_admin_profanities_path, class: "button"
+  
+  #importModal.modal.fade aria-hidden="true" aria-labelledby="ModalCenterTitle" role="dialog" tabindex="-1" 
+    .modal-dialog.modal-dialog-centered role="document" 
+      = simple_form_for :profanities_placeholder, url: import_profanities_admin_profanities_path, method: :post do |f|        
+        .modal-content
+          .modal-header
+            h5.modal-title Upload File To Import Profane Words
+            button.close aria-label="Close" data-dismiss="modal" type="button" 
+              span aria-hidden="true"  &times;
+          .modal-body
+                  .row.form-group.string.optional
+                    .col-md-12.form-label-group
+                      = link_to 'Click to download sample template' , "https://civis-production-api.s3.ap-south-1.amazonaws.com/Civis+-+Response+Import+Template.xlsx"
+                    .col-md-10.form-label-group
+                      = f.file_field :file, class: "p10"
+                    #loader-for-file-upload.col-md-2.form-label-group.hidden
+                      .loader
+          .modal-footer
+            button.btn.btn-secondary data-dismiss="modal" type="button"  Close
+            input.btn.square-btn-question id="file-upload-btn" type="submit" value="Import"

--- a/app/views/admin/profanities/new.html.slim
+++ b/app/views/admin/profanities/new.html.slim
@@ -1,0 +1,14 @@
+- navigation_add 'Profane Words', admin_profanities_path
+- navigation_add 'Create Profane Word', new_admin_profanity_path
+= render_navigation
+- flash.each do |key, value|
+	- if (key == "flash_info" || key == "flash_success_info")
+		div class=("alert #{key}") = value
+.admin-content-wrapper
+	.admin-filter-bg
+		.admin-filter-parent
+			.admin-filter-child.width-75
+				.admin-filter-child-field
+					.admin-index-title DETAILS
+	.admin-list-bg
+		= render 'form'

--- a/app/views/admin/profanities/show.html.slim
+++ b/app/views/admin/profanities/show.html.slim
@@ -1,0 +1,33 @@
+- navigation_add 'Profane Word', admin_profanities_path
+- navigation_add "#{@profanity&.profane_word}", admin_profanity_path(@profanity)
+= render_navigation
+- flash.each do |key, value|
+  - if (key == "flash_info" || key == "flash_success_info")
+    div class=("alert #{key}") = value
+.admin-content-wrapper
+  .admin-filter-bg
+    .admin-filter-parent
+      .admin-filter-child.width-75
+        .admin-filter-child-field
+          .admin-index-title DETAILS
+      .mr-3
+        .ellipsis-icon.fas.fa-ellipsis-h data-toggle="collapse" data-target="#show-page-dropdown"
+                .dropdown#dropdown-container
+                  ul.dropdown-menu.icon-list#show-page-dropdown
+                      li
+                        = link_to edit_admin_profanity_path(@profanity), method: :get do
+                          .dropdown-with-icon
+                            p Edit
+                            .pull-right.fa.fa-edit.pointer.fa-icon-color
+                      li
+                        = link_to admin_profanity_path(@profanity), method: :delete, data: { confirm: "Are you sure?" } do 
+                          .dropdown-with-icon
+                            p Delete
+                            .pull-right.fas.fa-trash-alt.pointer.fa-icon-color
+  .admin-list-bg      
+    .p-4
+      .admin-header-text
+        | Basic Information
+      .admin-details-box
+        = display_details("show-page-parent-details", "show-page-label-details", "Profane Word", "show-page-input-details", "#{@profanity&.profane_word || '-'}")
+        

--- a/app/views/layouts/_left_side_navbar.html.slim
+++ b/app/views/layouts/_left_side_navbar.html.slim
@@ -47,6 +47,11 @@
           div
             .far.fa-newspaper.pointer.pr-4 
             | Glossary
+      = link_to admin_profanities_path, class: "#{current_class?(admin_profanities_path)} #{params[:id].present? ? current_class?(admin_profanity_path(params[:id])) : '' } #{params[:id].present? ? current_class?(edit_admin_profanity_path(params[:id])) : '' }" do
+        li
+          div
+            .far.fa-newspaper.pointer.pr-4 
+            | Profanities
       = link_to admin_consultation_responses_path, class: "#{current_class?(admin_consultation_responses_path)} #{params[:id].present? ? current_class?(admin_consultation_response_path(params[:id])) : '' } #{params[:id].present? ? current_class?(edit_admin_consultation_response_path(params[:id])) : '' }" do
         li
           div

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,13 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :profanities do
+      collection do
+        get :export_as_excel
+        post :import_profanities
+      end
+    end
+
     resources :glossary_word_consultation_mappings
     resources :case_studies
     resources :categories

--- a/db/migrate/20210718071852_create_profanities.rb
+++ b/db/migrate/20210718071852_create_profanities.rb
@@ -1,0 +1,10 @@
+class CreateProfanities < ActiveRecord::Migration[6.0]
+  def change
+    create_table :profanities do |t|
+      t.string :profane_word
+      t.integer :created_by_id
+      t.timestamps
+    end
+    add_index :profanities, :profane_word, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_05_142332) do
+ActiveRecord::Schema.define(version: 2021_07_18_071852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -258,6 +258,14 @@ ActiveRecord::Schema.define(version: 2021_07_05_142332) do
     t.float "points"
   end
 
+  create_table "profanities", force: :cascade do |t|
+    t.string "profane_word"
+    t.integer "created_by_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["profane_word"], name: "index_profanities_on_profane_word", unique: true
+  end
+
   create_table "questions", force: :cascade do |t|
     t.integer "parent_id"
     t.string "question_text"
@@ -369,7 +377,7 @@ ActiveRecord::Schema.define(version: 2021_07_05_142332) do
     t.integer "created_by_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["word"], name: "index_wordindices_on_word"
+    t.index ["word"], name: "index_wordindices_on_word", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
Maintain profanities through the admin console. Import profanity data from a csv file and export the same to an excel sheet.